### PR TITLE
Update figure.html.twig

### DIFF
--- a/templates/partials/figure.html.twig
+++ b/templates/partials/figure.html.twig
@@ -10,5 +10,16 @@
             {{- attrs.title -}}
         {% endif %}
         </figcaption>
+    {% else %}
+        {# When title attribute is not defined, use the value of alt attribute of img element if defined #}
+        {% if attrs.alt %}
+            <figcaption>
+            {% if config.plugins.imgcaptions.markdown_title %}
+                {{- attrs.alt|markdown -}}
+            {% else %}
+                {{- attrs.alt -}}
+            {% endif %}
+            </figcaption>
+        {% endif %}
     {% endif %}
 </figure>


### PR DESCRIPTION
Cause it's easy to edit alt attribute for each img element in TinyMCE but infortunatly not title attribute, maybe it's interresting to get the alt attribute as caption ? I changed the twg figure template for thet.